### PR TITLE
Post 내 nested schema에 대한 resolver 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm") version "1.9.25" apply false
     kotlin("plugin.spring") version "1.9.25" apply false
     kotlin("plugin.jpa") version "1.9.25" apply false
+    kotlin("plugin.noarg") version "1.9.25" apply false
     id("org.springframework.boot") version "3.5.5" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
     id("com.netflix.dgs.codegen") version "7.0.3" apply false

--- a/radiant-app/src/test/kotlin/ink/radiant/e2e/PostGraphQLTest.kt
+++ b/radiant-app/src/test/kotlin/ink/radiant/e2e/PostGraphQLTest.kt
@@ -1,7 +1,13 @@
 package ink.radiant.e2e
 
 import ink.radiant.base.BaseGraphQLTest
+import ink.radiant.fixture.AccountEntityFixture
 import ink.radiant.fixture.PostEntityFixture
+import ink.radiant.infrastructure.entity.PostEntity
+import ink.radiant.infrastructure.entity.PostParticipantEntity
+import ink.radiant.infrastructure.entity.ProfessionalField
+import ink.radiant.infrastructure.repository.AccountRepository
+import ink.radiant.infrastructure.repository.PostParticipantRepository
 import ink.radiant.infrastructure.repository.PostRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -15,16 +21,180 @@ class PostGraphQLTest : BaseGraphQLTest() {
     @Autowired
     private lateinit var postRepository: PostRepository
 
+    @Autowired
+    private lateinit var accountRepository: AccountRepository
+
+    @Autowired
+    private lateinit var postParticipantRepository: PostParticipantRepository
+
     @BeforeEach
     @Transactional
     fun setUp() {
+        postParticipantRepository.deleteAll()
         postRepository.deleteAll()
+        accountRepository.deleteAll()
         setupTestData()
     }
 
     private fun setupTestData() {
-        val testPosts = PostEntityFixture.createPostEntityList()
-        postRepository.saveAll(testPosts)
+        val authorIds = createAuthors()
+        val savedPosts = postRepository.saveAll(createPosts(authorIds))
+        setupParticipants(savedPosts)
+    }
+
+    private fun createAuthors(): List<String> {
+        val authorOne = AccountEntityFixture.createAccount(
+            email = "author1@example.com",
+            name = "author_one",
+            providerId = "author-one",
+            displayName = "Author One",
+            avatarUrl = "https://example.com/avatar-author1.jpg",
+        )
+        authorOne.profile!!.apply {
+            bio = "백엔드 번역가"
+            location = "Seoul"
+            websiteUrl = "https://author.one"
+            postsCount = 20
+            viewsCount = 840L
+            followersCount = 112
+            followingCount = 33
+            professionalFields.add(ProfessionalField.BACKEND)
+        }
+        val savedAuthorOne = accountRepository.save(authorOne)
+
+        val authorTwo = AccountEntityFixture.createAccount(
+            email = "author2@example.com",
+            name = "author_two",
+            providerId = "author-two",
+            displayName = "Author Two",
+            avatarUrl = "https://example.com/avatar-author2.jpg",
+        )
+        authorTwo.profile!!.apply {
+            bio = "프론트엔드 전문 번역가"
+            location = "Busan"
+            websiteUrl = "https://author.two"
+            postsCount = 15
+            viewsCount = 560L
+            followersCount = 76
+            followingCount = 29
+            professionalFields.addAll(listOf(ProfessionalField.FRONTEND, ProfessionalField.AI_ML))
+        }
+        val savedAuthorTwo = accountRepository.save(authorTwo)
+
+        return listOf(savedAuthorOne.id, savedAuthorTwo.id)
+    }
+
+    private fun createPosts(authorIds: List<String>): List<PostEntity> {
+        val authorOneId = authorIds[0]
+        val authorTwoId = authorIds[1]
+
+        return listOf(
+            PostEntityFixture.createPostEntity(
+                id = "00000000-0000-0000-0000-000000000001",
+                title = "첫 번째 포스트",
+                body = "첫 번째 포스트의 내용입니다.",
+                translatedTitle = "First Post",
+                originalSentences = "첫 번째 문장\n두 번째 문장",
+                translatedSentences = "First sentence\nSecond sentence",
+                likes = 10,
+                commentsCount = 5,
+                thumbnailUrl = "https://example.com/thumb1.jpg",
+                authorId = authorOneId,
+            ),
+            PostEntityFixture.createPostEntity(
+                id = "00000000-0000-0000-0000-000000000002",
+                title = "두 번째 포스트",
+                body = "두 번째 포스트의 내용입니다.",
+                translatedTitle = "Second Post",
+                originalSentences = "안녕하세요\n반갑습니다",
+                translatedSentences = "Hello\nNice to meet you",
+                likes = 20,
+                commentsCount = 8,
+                thumbnailUrl = "https://example.com/thumb2.jpg",
+                authorId = authorTwoId,
+            ),
+            PostEntityFixture.createPostEntity(
+                id = "00000000-0000-0000-0000-000000000003",
+                title = "세 번째 포스트",
+                body = "세 번째 포스트의 내용입니다.",
+                translatedTitle = "Third Post",
+                originalSentences = "좋은 하루\n되세요",
+                translatedSentences = "Have a good day\nThank you",
+                likes = 15,
+                commentsCount = 3,
+                thumbnailUrl = "https://example.com/thumb3.jpg",
+                authorId = authorOneId,
+            ),
+        )
+    }
+
+    private fun setupParticipants(savedPosts: List<PostEntity>) {
+        val thirdPost = savedPosts.first { it.id == "00000000-0000-0000-0000-000000000003" }
+        val firstPost = savedPosts.first { it.id == "00000000-0000-0000-0000-000000000001" }
+
+        val translatorOne = AccountEntityFixture.createAccount(
+            email = "translator1@example.com",
+            name = "translator_one",
+            providerId = "translator-one",
+            displayName = "Translator One",
+            avatarUrl = "https://example.com/avatar-translator1.jpg",
+        )
+        translatorOne.profile!!.apply {
+            bio = "전문 번역가"
+            location = "Seoul"
+            websiteUrl = "https://translator.one"
+            postsCount = 12
+            viewsCount = 420L
+            followersCount = 58
+            followingCount = 15
+            professionalFields.add(ProfessionalField.BACKEND)
+        }
+        val savedTranslatorOne = accountRepository.save(translatorOne)
+
+        val translatorTwo = AccountEntityFixture.createAccount(
+            email = "translator2@example.com",
+            name = "translator_two",
+            providerId = "translator-two",
+            displayName = "Translator Two",
+            avatarUrl = "https://example.com/avatar-translator2.jpg",
+        )
+        translatorTwo.profile!!.apply {
+            bio = "AI 번역 전문가"
+            location = "Busan"
+            websiteUrl = "https://translator.two"
+            postsCount = 8
+            viewsCount = 275L
+            followersCount = 34
+            followingCount = 22
+            professionalFields.addAll(listOf(ProfessionalField.AI_ML, ProfessionalField.FRONTEND))
+        }
+        val savedTranslatorTwo = accountRepository.save(translatorTwo)
+
+        val translatorThree = AccountEntityFixture.createAccount(
+            email = "translator3@example.com",
+            name = "translator_three",
+            providerId = "translator-three",
+            displayName = "Translator Three",
+            avatarUrl = "https://example.com/avatar-translator3.jpg",
+        )
+        translatorThree.profile!!.apply {
+            bio = "커뮤니티 기여자"
+            location = "Daegu"
+            postsCount = 5
+            viewsCount = 150L
+            followersCount = 21
+            followingCount = 11
+            professionalFields.add(ProfessionalField.DEVOPS)
+        }
+        val savedTranslatorThree = accountRepository.save(translatorThree)
+
+        postParticipantRepository.saveAll(
+            listOf(
+                PostParticipantEntity(post = thirdPost, profile = savedTranslatorOne.profile!!),
+                PostParticipantEntity(post = thirdPost, profile = savedTranslatorTwo.profile!!),
+                PostParticipantEntity(post = firstPost, profile = savedTranslatorThree.profile!!),
+            ),
+        )
     }
 
     @Test
@@ -36,10 +206,26 @@ class PostGraphQLTest : BaseGraphQLTest() {
                         node {
                             id
                             title
-                            body
-                            likesCount
-                            commentsCount
-                            createdAt
+                        body
+                        likesCount
+                        commentsCount
+                        createdAt
+                        author {
+                            id
+                            username
+                            name
+                        }
+                        participants {
+                            totalCount
+                            edges {
+                                node {
+                                        id
+                                        username
+                                        name
+                                    }
+                                    cursor
+                                }
+                            }
                         }
                         cursor
                     }
@@ -61,6 +247,11 @@ class PostGraphQLTest : BaseGraphQLTest() {
             .jsonPath("$.data.posts.edges.length()").isEqualTo(2)
             .jsonPath("$.data.posts.edges[0].node.title").isEqualTo("세 번째 포스트")
             .jsonPath("$.data.posts.edges[1].node.title").isEqualTo("두 번째 포스트")
+            .jsonPath("$.data.posts.edges[0].node.author.username").isEqualTo("author_one")
+            .jsonPath("$.data.posts.edges[0].node.author.name").isEqualTo("Author One")
+            .jsonPath("$.data.posts.edges[0].node.participants.totalCount").isEqualTo(2)
+            .jsonPath("$.data.posts.edges[0].node.participants.edges[0].node.username").isEqualTo("translator_one")
+            .jsonPath("$.data.posts.edges[0].node.participants.edges[1].node.username").isEqualTo("translator_two")
             .jsonPath("$.data.posts.pageInfo.hasNextPage").isEqualTo(true)
             .jsonPath("$.data.posts.pageInfo.hasPreviousPage").isEqualTo(false)
     }
@@ -81,6 +272,21 @@ class PostGraphQLTest : BaseGraphQLTest() {
                         thumbnailUrl
                         createdAt
                         updatedAt
+                        author {
+                            id
+                            username
+                            name
+                        }
+                        participants {
+                            totalCount
+                            edges {
+                                node {
+                                    id
+                                    username
+                                    name
+                                }
+                            }
+                        }
                     }
                     ... on PostNotFoundError {
                         message
@@ -101,6 +307,10 @@ class PostGraphQLTest : BaseGraphQLTest() {
             .jsonPath("$.data.post.originalSentences[1]").isEqualTo("두 번째 문장")
             .jsonPath("$.data.post.likesCount").isEqualTo(10)
             .jsonPath("$.data.post.commentsCount").isEqualTo(5)
+            .jsonPath("$.data.post.author.username").isEqualTo("author_one")
+            .jsonPath("$.data.post.author.name").isEqualTo("Author One")
+            .jsonPath("$.data.post.participants.totalCount").isEqualTo(1)
+            .jsonPath("$.data.post.participants.edges[0].node.username").isEqualTo("translator_three")
     }
 
     @Test

--- a/radiant-app/src/test/kotlin/ink/radiant/fixture/AccountEntityFixture.kt
+++ b/radiant-app/src/test/kotlin/ink/radiant/fixture/AccountEntityFixture.kt
@@ -1,0 +1,25 @@
+package ink.radiant.fixture
+
+import ink.radiant.infrastructure.entity.AccountEntity
+import ink.radiant.infrastructure.entity.OAuthProvider
+
+object AccountEntityFixture {
+
+    fun createAccount(
+        email: String,
+        name: String,
+        provider: OAuthProvider = OAuthProvider.GITHUB,
+        providerId: String,
+        displayName: String,
+        avatarUrl: String? = null,
+    ): AccountEntity {
+        return AccountEntity.signUp(
+            email = email,
+            name = name,
+            provider = provider,
+            providerId = providerId,
+            displayName = displayName,
+            avatarUrl = avatarUrl,
+        )
+    }
+}

--- a/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
+++ b/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
@@ -139,7 +139,7 @@ class PostServiceImpl(
         val account = accountRepository.findById(authorId).orElse(null) ?: return null
         val profile = account.profile
 
-        val joinedAt = account.createdAt ?: profile?.createdAt ?: OffsetDateTime.now()
+        val joinedAt = account.createdAt ?: profile?.createdAt ?: OffsetDateTime.MIN
 
         return if (profile != null) {
             PostAuthor(
@@ -214,7 +214,7 @@ class PostServiceImpl(
     private fun PostParticipantEntity.toDomainParticipant(): PostParticipant {
         val profile = this.profile
         val account = profile.account
-        val joinedAt = account.createdAt ?: profile.createdAt ?: OffsetDateTime.now()
+        val joinedAt = account.createdAt ?: profile.createdAt ?: OffsetDateTime.MIN
 
         return PostParticipant(
             id = account.id,

--- a/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
+++ b/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
@@ -147,39 +147,21 @@ class PostServiceImpl(
 
         val joinedAt = account.createdAt ?: profile?.createdAt ?: OffsetDateTime.MIN
 
-        return if (profile != null) {
-            PostAuthor(
-                id = account.id,
-                username = account.name,
-                name = profile.displayName,
-                avatarUrl = profile.avatarUrl,
-                bio = profile.bio,
-                location = profile.location,
-                websiteUrl = profile.websiteUrl,
-                joinedAt = joinedAt,
-                postsCount = profile.postsCount,
-                viewsCount = profile.viewsCount,
-                followersCount = profile.followersCount,
-                followingCount = profile.followingCount,
-                professionalFields = profile.professionalFields.map { it.name }.toSet(),
-            )
-        } else {
-            PostAuthor(
-                id = account.id,
-                username = account.name,
-                name = account.displayName,
-                avatarUrl = account.avatarUrl,
-                bio = null,
-                location = null,
-                websiteUrl = null,
-                joinedAt = joinedAt,
-                postsCount = 0,
-                viewsCount = 0,
-                followersCount = 0,
-                followingCount = 0,
-                professionalFields = emptySet(),
-            )
-        }
+        return PostAuthor(
+            id = account.id,
+            username = account.name,
+            name = profile?.displayName ?: account.displayName,
+            avatarUrl = profile?.avatarUrl ?: account.avatarUrl,
+            bio = profile?.bio,
+            location = profile?.location,
+            websiteUrl = profile?.websiteUrl,
+            joinedAt = joinedAt,
+            postsCount = profile?.postsCount ?: 0,
+            viewsCount = profile?.viewsCount ?: 0L,
+            followersCount = profile?.followersCount ?: 0,
+            followingCount = profile?.followingCount ?: 0,
+            professionalFields = profile?.professionalFields?.map { it.name }?.toSet() ?: emptySet(),
+        )
     }
 
     private fun encodeCursor(dateTime: OffsetDateTime): String {

--- a/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
+++ b/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
@@ -3,13 +3,22 @@ package ink.radiant.command.service
 import ink.radiant.core.domain.event.PostViewedEvent
 import ink.radiant.core.domain.model.PageInfo
 import ink.radiant.core.domain.model.Post
+import ink.radiant.core.domain.model.PostAuthor
 import ink.radiant.core.domain.model.PostConnection
 import ink.radiant.core.domain.model.PostEdge
+import ink.radiant.core.domain.model.PostParticipant
+import ink.radiant.core.domain.model.PostParticipantConnection
+import ink.radiant.core.domain.model.PostParticipantEdge
+import ink.radiant.infrastructure.entity.PostParticipantEntity
 import ink.radiant.infrastructure.mapper.PostQueryMapper
 import ink.radiant.infrastructure.messaging.EventPublisher
+import ink.radiant.infrastructure.repository.AccountRepository
+import ink.radiant.infrastructure.repository.PostParticipantRepository
 import ink.radiant.query.service.PostQueryService
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.nio.charset.StandardCharsets
 import java.time.OffsetDateTime
 import java.util.Base64
 
@@ -18,6 +27,8 @@ import java.util.Base64
 class PostServiceImpl(
     private val postQueryMapper: PostQueryMapper,
     private val eventPublisher: EventPublisher,
+    private val postParticipantRepository: PostParticipantRepository,
+    private val accountRepository: AccountRepository,
 ) : PostCommandService, PostQueryService {
 
     override fun findPosts(first: Int?, after: String?): PostConnection {
@@ -80,12 +91,158 @@ class PostServiceImpl(
             .map { it.toDomainModel() }
     }
 
+    override fun findParticipants(postId: String, first: Int?, after: String?): PostParticipantConnection {
+        val limit = (first ?: DEFAULT_PARTICIPANT_LIMIT).coerceIn(1, MAX_PARTICIPANT_LIMIT)
+        val totalCount = postParticipantRepository.countActiveByPostId(postId).toInt()
+        if (totalCount == 0) {
+            return emptyParticipantConnection()
+        }
+
+        val anchor = after?.let { decodeParticipantCursor(it) }
+        val pageable = PageRequest.of(0, limit + 1)
+        val participants = postParticipantRepository.findActiveByPostId(
+            postId = postId,
+            cursorCreatedAt = anchor?.createdAt,
+            cursorId = anchor?.id,
+            pageable = pageable,
+        )
+
+        if (participants.isEmpty()) {
+            return emptyParticipantConnection()
+        }
+
+        val hasNextPage = participants.size > limit
+        val visibleParticipants = if (hasNextPage) participants.dropLast(1) else participants
+
+        val edges = visibleParticipants.map { entity ->
+            PostParticipantEdge(
+                participant = entity.toDomainParticipant(),
+                cursor = encodeParticipantCursor(entity),
+            )
+        }
+
+        val pageInfo = PageInfo(
+            hasNextPage = hasNextPage,
+            hasPreviousPage = after != null,
+            startCursor = edges.firstOrNull()?.cursor,
+            endCursor = edges.lastOrNull()?.cursor,
+        )
+
+        return PostParticipantConnection(
+            edges = edges,
+            pageInfo = pageInfo,
+            totalCount = totalCount,
+        )
+    }
+
+    override fun findAuthor(authorId: String): PostAuthor? {
+        val account = accountRepository.findById(authorId).orElse(null) ?: return null
+        val profile = account.profile
+
+        val joinedAt = account.createdAt ?: profile?.createdAt ?: OffsetDateTime.now()
+
+        return if (profile != null) {
+            PostAuthor(
+                id = account.id,
+                username = account.name,
+                name = profile.displayName,
+                avatarUrl = profile.avatarUrl,
+                bio = profile.bio,
+                location = profile.location,
+                websiteUrl = profile.websiteUrl,
+                joinedAt = joinedAt,
+                postsCount = profile.postsCount,
+                viewsCount = profile.viewsCount,
+                followersCount = profile.followersCount,
+                followingCount = profile.followingCount,
+                professionalFields = profile.professionalFields.map { it.name }.toSet(),
+            )
+        } else {
+            PostAuthor(
+                id = account.id,
+                username = account.name,
+                name = account.displayName,
+                avatarUrl = account.avatarUrl,
+                bio = null,
+                location = null,
+                websiteUrl = null,
+                joinedAt = joinedAt,
+                postsCount = 0,
+                viewsCount = 0,
+                followersCount = 0,
+                followingCount = 0,
+                professionalFields = emptySet(),
+            )
+        }
+    }
+
     private fun encodeCursor(dateTime: OffsetDateTime): String {
-        return Base64.getEncoder().encodeToString(dateTime.toString().toByteArray())
+        return Base64.getEncoder().encodeToString(dateTime.toString().toByteArray(StandardCharsets.UTF_8))
     }
 
     private fun decodeCursor(cursor: String): OffsetDateTime {
-        val decoded = String(Base64.getDecoder().decode(cursor))
+        val decoded = String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8)
         return OffsetDateTime.parse(decoded)
+    }
+
+    private fun encodeParticipantCursor(entity: PostParticipantEntity): String {
+        val createdAt = entity.safeCreatedAt()
+        val rawCursor = "$createdAt|${entity.id}"
+        return Base64.getEncoder().encodeToString(rawCursor.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private fun decodeParticipantCursor(cursor: String): ParticipantCursor {
+        val decoded = String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8)
+        val parts = decoded.split("|")
+        require(parts.size == 2) { "Invalid cursor format" }
+        val createdAt = OffsetDateTime.parse(parts[0])
+        val id = parts[1]
+        return ParticipantCursor(createdAt = createdAt, id = id)
+    }
+
+    private fun emptyParticipantConnection(): PostParticipantConnection = PostParticipantConnection(
+        edges = emptyList(),
+        pageInfo = PageInfo(
+            hasNextPage = false,
+            hasPreviousPage = false,
+            startCursor = null,
+            endCursor = null,
+        ),
+        totalCount = 0,
+    )
+
+    private fun PostParticipantEntity.toDomainParticipant(): PostParticipant {
+        val profile = this.profile
+        val account = profile.account
+        val joinedAt = account.createdAt ?: profile.createdAt ?: OffsetDateTime.now()
+
+        return PostParticipant(
+            id = account.id,
+            username = account.name,
+            name = profile.displayName,
+            avatarUrl = profile.avatarUrl,
+            bio = profile.bio,
+            location = profile.location,
+            websiteUrl = profile.websiteUrl,
+            joinedAt = joinedAt,
+            postsCount = profile.postsCount,
+            viewsCount = profile.viewsCount,
+            followersCount = profile.followersCount,
+            followingCount = profile.followingCount,
+            professionalFields = profile.professionalFields.map { it.name }.toSet(),
+        )
+    }
+
+    private fun PostParticipantEntity.safeCreatedAt(): OffsetDateTime =
+        this.createdAt ?: this.updatedAt ?: OffsetDateTime.MIN
+
+    private data class ParticipantCursor(
+        val createdAt: OffsetDateTime,
+        val id: String,
+    )
+
+    companion object {
+        private const val DEFAULT_PARTICIPANT_LIMIT = 10
+        private const val MAX_PARTICIPANT_LIMIT = 50
     }
 }

--- a/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
+++ b/radiant-command/src/main/kotlin/ink/radiant/command/service/PostServiceImpl.kt
@@ -95,7 +95,10 @@ class PostServiceImpl(
         val limit = (first ?: DEFAULT_PARTICIPANT_LIMIT).coerceIn(1, MAX_PARTICIPANT_LIMIT)
         val totalCount = postParticipantRepository.countActiveByPostId(postId).toInt()
         if (totalCount == 0) {
-            return emptyParticipantConnection()
+            return emptyParticipantConnection(
+                totalCount = 0,
+                hasPreviousPage = false,
+            )
         }
 
         val anchor = after?.let { decodeParticipantCursor(it) }
@@ -108,7 +111,10 @@ class PostServiceImpl(
         )
 
         if (participants.isEmpty()) {
-            return emptyParticipantConnection()
+            return emptyParticipantConnection(
+                totalCount = totalCount,
+                hasPreviousPage = after != null,
+            )
         }
 
         val hasNextPage = participants.size > limit
@@ -200,16 +206,17 @@ class PostServiceImpl(
         return ParticipantCursor(createdAt = createdAt, id = id)
     }
 
-    private fun emptyParticipantConnection(): PostParticipantConnection = PostParticipantConnection(
-        edges = emptyList(),
-        pageInfo = PageInfo(
-            hasNextPage = false,
-            hasPreviousPage = false,
-            startCursor = null,
-            endCursor = null,
-        ),
-        totalCount = 0,
-    )
+    private fun emptyParticipantConnection(totalCount: Int, hasPreviousPage: Boolean): PostParticipantConnection =
+        PostParticipantConnection(
+            edges = emptyList(),
+            pageInfo = PageInfo(
+                hasNextPage = false,
+                hasPreviousPage = hasPreviousPage,
+                startCursor = null,
+                endCursor = null,
+            ),
+            totalCount = totalCount,
+        )
 
     private fun PostParticipantEntity.toDomainParticipant(): PostParticipant {
         val profile = this.profile

--- a/radiant-command/src/main/kotlin/ink/radiant/command/service/UserCommandService.kt
+++ b/radiant-command/src/main/kotlin/ink/radiant/command/service/UserCommandService.kt
@@ -1,7 +1,7 @@
 package ink.radiant.command.service
 
-import ink.radiant.core.domain.model.User
+import ink.radiant.core.domain.model.Account
 
 interface UserCommandService {
-    fun findOrCreateUser(oauthUser: User): User
+    fun findOrCreateUser(oauthAccount: Account): Account
 }

--- a/radiant-command/src/main/kotlin/ink/radiant/command/service/UserServiceImpl.kt
+++ b/radiant-command/src/main/kotlin/ink/radiant/command/service/UserServiceImpl.kt
@@ -1,7 +1,7 @@
 package ink.radiant.command.service
 
-import ink.radiant.core.domain.model.OAuthUser
-import ink.radiant.core.domain.model.User
+import ink.radiant.core.domain.model.Account
+import ink.radiant.core.domain.model.OAuthAccount
 import ink.radiant.infrastructure.entity.AccountEntity
 import ink.radiant.infrastructure.entity.OAuthProvider
 import ink.radiant.infrastructure.repository.AccountRepository
@@ -17,7 +17,7 @@ class UserServiceImpl(
     private val profileRepository: ProfileRepository,
 ) : UserCommandService, UserQueryService {
 
-    override fun findOrCreateUser(oauthUser: OAuthUser): User {
+    override fun findOrCreateUser(oauthUser: OAuthAccount): Account {
         val provider = OAuthProvider.valueOf(oauthUser.provider.uppercase())
         val existingAccount =
             accountRepository.findByProviderIdAndProvider(oauthUser.id, provider)
@@ -29,14 +29,14 @@ class UserServiceImpl(
         }
     }
 
-    private fun updateLastLoginInfo(existingAccount: AccountEntity): User {
+    private fun updateLastLoginInfo(existingAccount: AccountEntity): Account {
         existingAccount.updateLastLogin()
 
         val savedAccount = accountRepository.save(existingAccount)
         return convertToUser(savedAccount)
     }
 
-    private fun createNewUser(oauthUser: OAuthUser): User {
+    private fun createNewUser(oauthUser: OAuthAccount): Account {
         val provider = OAuthProvider.valueOf(oauthUser.provider.uppercase())
         val displayName = generateUniqueDisplayName(oauthUser.username)
 
@@ -66,7 +66,7 @@ class UserServiceImpl(
         return username
     }
 
-    private fun convertToUser(account: AccountEntity): User = User(
+    private fun convertToUser(account: AccountEntity): Account = Account(
         id = account.id,
         username = account.name,
         name = account.displayName,

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/Account.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/Account.kt
@@ -1,0 +1,12 @@
+package ink.radiant.core.domain.model
+
+data class Account(
+    val id: String,
+    val username: String,
+    val name: String,
+    val email: String,
+    val avatarUrl: String? = null,
+    val provider: String,
+)
+
+typealias OAuthAccount = Account

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PageInfo.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PageInfo.kt
@@ -1,0 +1,8 @@
+package ink.radiant.core.domain.model
+
+data class PageInfo(
+    val hasNextPage: Boolean,
+    val hasPreviousPage: Boolean,
+    val startCursor: String?,
+    val endCursor: String?,
+)

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostAuthor.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostAuthor.kt
@@ -1,19 +1,3 @@
 package ink.radiant.core.domain.model
 
-import java.time.OffsetDateTime
-
-data class PostAuthor(
-    val id: String,
-    val username: String,
-    val name: String,
-    val avatarUrl: String?,
-    val bio: String?,
-    val location: String?,
-    val websiteUrl: String?,
-    val joinedAt: OffsetDateTime,
-    val postsCount: Int,
-    val viewsCount: Long,
-    val followersCount: Int,
-    val followingCount: Int,
-    val professionalFields: Set<String>,
-)
+typealias PostAuthor = User

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostAuthor.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostAuthor.kt
@@ -1,0 +1,19 @@
+package ink.radiant.core.domain.model
+
+import java.time.OffsetDateTime
+
+data class PostAuthor(
+    val id: String,
+    val username: String,
+    val name: String,
+    val avatarUrl: String?,
+    val bio: String?,
+    val location: String?,
+    val websiteUrl: String?,
+    val joinedAt: OffsetDateTime,
+    val postsCount: Int,
+    val viewsCount: Long,
+    val followersCount: Int,
+    val followingCount: Int,
+    val professionalFields: Set<String>,
+)

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostConnection.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostConnection.kt
@@ -10,10 +10,3 @@ data class PostEdge(
     val post: Post,
     val cursor: String,
 )
-
-data class PageInfo(
-    val hasNextPage: Boolean,
-    val hasPreviousPage: Boolean,
-    val startCursor: String?,
-    val endCursor: String?,
-)

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostParticipantConnection.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostParticipantConnection.kt
@@ -1,0 +1,33 @@
+package ink.radiant.core.domain.model
+
+import java.time.OffsetDateTime
+
+/**
+ * Represents a participant involved with a post alongside pagination helpers.
+ */
+data class PostParticipantConnection(
+    val edges: List<PostParticipantEdge>,
+    val pageInfo: PageInfo,
+    val totalCount: Int,
+)
+
+data class PostParticipantEdge(
+    val participant: PostParticipant,
+    val cursor: String,
+)
+
+data class PostParticipant(
+    val id: String,
+    val username: String,
+    val name: String,
+    val avatarUrl: String?,
+    val bio: String?,
+    val location: String?,
+    val websiteUrl: String?,
+    val joinedAt: OffsetDateTime,
+    val postsCount: Int,
+    val viewsCount: Long,
+    val followersCount: Int,
+    val followingCount: Int,
+    val professionalFields: Set<String>,
+)

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostParticipantConnection.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/PostParticipantConnection.kt
@@ -1,10 +1,5 @@
 package ink.radiant.core.domain.model
 
-import java.time.OffsetDateTime
-
-/**
- * Represents a participant involved with a post alongside pagination helpers.
- */
 data class PostParticipantConnection(
     val edges: List<PostParticipantEdge>,
     val pageInfo: PageInfo,
@@ -16,18 +11,4 @@ data class PostParticipantEdge(
     val cursor: String,
 )
 
-data class PostParticipant(
-    val id: String,
-    val username: String,
-    val name: String,
-    val avatarUrl: String?,
-    val bio: String?,
-    val location: String?,
-    val websiteUrl: String?,
-    val joinedAt: OffsetDateTime,
-    val postsCount: Int,
-    val viewsCount: Long,
-    val followersCount: Int,
-    val followingCount: Int,
-    val professionalFields: Set<String>,
-)
+typealias PostParticipant = User

--- a/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/User.kt
+++ b/radiant-core/src/main/kotlin/ink/radiant/core/domain/model/User.kt
@@ -1,12 +1,19 @@
 package ink.radiant.core.domain.model
 
+import java.time.OffsetDateTime
+
 data class User(
     val id: String,
     val username: String,
     val name: String,
-    val email: String,
-    val avatarUrl: String? = null,
-    val provider: String,
+    val avatarUrl: String?,
+    val bio: String?,
+    val location: String?,
+    val websiteUrl: String?,
+    val joinedAt: OffsetDateTime,
+    val postsCount: Int,
+    val viewsCount: Long,
+    val followersCount: Int,
+    val followingCount: Int,
+    val professionalFields: Set<String>,
 )
-
-typealias OAuthUser = User

--- a/radiant-infrastructure/build.gradle.kts
+++ b/radiant-infrastructure/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     kotlin("jvm")
     kotlin("plugin.spring")
+    kotlin("plugin.jpa")
+    kotlin("plugin.noarg")
     id("io.spring.dependency-management")
 }
 
@@ -25,6 +27,18 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+}
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
+}
+
+noArg {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
 }
 
 tasks.withType<Test> {

--- a/radiant-infrastructure/src/main/kotlin/ink/radiant/infrastructure/entity/PostParticipantEntity.kt
+++ b/radiant-infrastructure/src/main/kotlin/ink/radiant/infrastructure/entity/PostParticipantEntity.kt
@@ -1,0 +1,32 @@
+package ink.radiant.infrastructure.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "post_participants")
+class PostParticipantEntity(
+    @Id
+    @Column(name = "id")
+    var id: String = UUID.randomUUID().toString(),
+) : BaseEntity() {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    lateinit var post: PostEntity
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id", nullable = false)
+    lateinit var profile: ProfileEntity
+
+    constructor(post: PostEntity, profile: ProfileEntity) : this() {
+        this.post = post
+        this.profile = profile
+    }
+}

--- a/radiant-infrastructure/src/main/kotlin/ink/radiant/infrastructure/repository/PostParticipantRepository.kt
+++ b/radiant-infrastructure/src/main/kotlin/ink/radiant/infrastructure/repository/PostParticipantRepository.kt
@@ -1,0 +1,29 @@
+package ink.radiant.infrastructure.repository
+
+import ink.radiant.infrastructure.entity.PostParticipantEntity
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+
+@Repository
+interface PostParticipantRepository : JpaRepository<PostParticipantEntity, String> {
+
+    @Query(
+        "SELECT pp FROM PostParticipantEntity pp " +
+            "WHERE pp.post.id = :postId AND pp.deletedAt IS NULL " +
+            "AND (:cursorCreatedAt IS NULL OR pp.createdAt > :cursorCreatedAt " +
+            "   OR (pp.createdAt = :cursorCreatedAt AND (:cursorId IS NULL OR pp.id > :cursorId))) " +
+            "ORDER BY pp.createdAt ASC, pp.id ASC",
+    )
+    fun findActiveByPostId(
+        postId: String,
+        cursorCreatedAt: OffsetDateTime?,
+        cursorId: String?,
+        pageable: Pageable,
+    ): List<PostParticipantEntity>
+
+    @Query("SELECT COUNT(pp) FROM PostParticipantEntity pp WHERE pp.post.id = :postId AND pp.deletedAt IS NULL")
+    fun countActiveByPostId(postId: String): Long
+}

--- a/radiant-query/src/main/kotlin/ink/radiant/query/service/PostQueryService.kt
+++ b/radiant-query/src/main/kotlin/ink/radiant/query/service/PostQueryService.kt
@@ -1,9 +1,14 @@
 package ink.radiant.query.service
 
 import ink.radiant.core.domain.model.Post
+import ink.radiant.core.domain.model.PostAuthor
 import ink.radiant.core.domain.model.PostConnection
+import ink.radiant.core.domain.model.PostParticipantConnection
+
 interface PostQueryService {
     fun findPosts(first: Int?, after: String?): PostConnection
     fun findPostById(id: String): Post?
     fun findPostsByIds(ids: List<String>): List<Post>
+    fun findParticipants(postId: String, first: Int?, after: String?): PostParticipantConnection
+    fun findAuthor(authorId: String): PostAuthor?
 }

--- a/radiant-web/src/main/kotlin/ink/radiant/web/datafetcher/PostDataFetcher.kt
+++ b/radiant-web/src/main/kotlin/ink/radiant/web/datafetcher/PostDataFetcher.kt
@@ -1,8 +1,12 @@
 package ink.radiant.web.datafetcher
 
 import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsData
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
+import ink.radiant.core.domain.model.PostAuthor
+import ink.radiant.core.domain.model.PostParticipantConnection
 import ink.radiant.query.service.PostQueryService
 import ink.radiant.web.codegen.types.PageInfo
 import ink.radiant.web.codegen.types.Post
@@ -13,6 +17,7 @@ import ink.radiant.web.codegen.types.PostResult
 import ink.radiant.web.codegen.types.ProfessionalField
 import ink.radiant.web.codegen.types.User
 import ink.radiant.web.codegen.types.UserConnection
+import ink.radiant.web.codegen.types.UserEdge
 import java.time.OffsetDateTime
 
 @DgsComponent
@@ -21,8 +26,13 @@ class PostDataFetcher(
 ) {
 
     @DgsQuery
-    fun posts(@InputArgument first: Int?, @InputArgument after: String?): PostConnection {
+    fun posts(
+        @InputArgument first: Int?,
+        @InputArgument after: String?,
+        dfe: DgsDataFetchingEnvironment,
+    ): PostConnection {
         val connection = postQueryService.findPosts(first, after)
+        storePostsInContext(dfe, connection.edges.map { it.post })
 
         return PostConnection(
             edges = connection.edges.map { edge ->
@@ -42,8 +52,10 @@ class PostDataFetcher(
     }
 
     @DgsQuery
-    fun post(@InputArgument id: String): PostResult {
+    fun post(@InputArgument id: String, dfe: DgsDataFetchingEnvironment): PostResult {
         val post = postQueryService.findPostById(id)
+        post?.let { storePostsInContext(dfe, listOf(it)) }
+
         return post?.toGraphQLPost()
             ?: PostNotFoundError(
                 message = "Post with id '$id' not found",
@@ -51,75 +63,197 @@ class PostDataFetcher(
                 postId = id,
             )
     }
+
+    @DgsData(parentType = POST_TYPE, field = PARTICIPANTS_FIELD)
+    fun participants(
+        dfe: DgsDataFetchingEnvironment,
+        @InputArgument first: Int?,
+        @InputArgument after: String?,
+    ): UserConnection {
+        val source = dfe.getSource<Post>()
+
+        val context = (dfe.graphQlContext.get(CONTEXT_KEY) as? PostParticipantsContext)
+            ?: PostParticipantsContext().also { dfe.graphQlContext.put(CONTEXT_KEY, it) }
+
+        val domainPost = context.postsById[source.id]
+        val postId = domainPost?.id?.toString() ?: source.id
+        val effectiveFirst = first ?: DEFAULT_PARTICIPANT_LIMIT
+        val connection = postQueryService.findParticipants(postId, effectiveFirst, after)
+
+        return connection.toGraphQLUserConnection()
+    }
+
+    @DgsData(parentType = POST_TYPE, field = AUTHOR_FIELD)
+    fun author(dfe: DgsDataFetchingEnvironment): User? {
+        val source = dfe.getSource<Post>()
+
+        val context = (dfe.graphQlContext.get(CONTEXT_KEY) as? PostParticipantsContext)
+            ?: PostParticipantsContext().also { dfe.graphQlContext.put(CONTEXT_KEY, it) }
+
+        val domainPost = context.postsById[source.id]
+        val authorId = domainPost?.authorId ?: source.author?.id ?: return null
+
+        val cachedAuthor = context.authorsById[authorId]
+        if (cachedAuthor != null) {
+            return cachedAuthor.toGraphQLUser()
+        }
+
+        val author = postQueryService.findAuthor(authorId) ?: return null
+        context.authorsById[authorId] = author
+
+        return author.toGraphQLUser()
+    }
+
+    private fun ink.radiant.core.domain.model.Post.toGraphQLPost(): Post = Post(
+        id = this.id.toString(),
+        title = this.title,
+        body = this.body,
+        translatedTitle = this.translatedTitle,
+        originalSentences = this.originalSentences,
+        translatedSentences = this.translatedSentences,
+        createdAt = this.createdAt,
+        updatedAt = this.updatedAt,
+        likesCount = this.likes,
+        commentsCount = this.commentsCount,
+        thumbnailUrl = this.thumbnailUrl,
+        author = null,
+        participants = emptyUserConnection(),
+    )
+
+    private fun PostParticipantConnection.toGraphQLUserConnection(): UserConnection {
+        return UserConnection(
+            edges = this.edges.map { edge ->
+                UserEdge(
+                    node = edge.participant.toGraphQLUser(),
+                    cursor = edge.cursor,
+                )
+            },
+            pageInfo = PageInfo(
+                hasNextPage = this.pageInfo.hasNextPage,
+                hasPreviousPage = this.pageInfo.hasPreviousPage,
+                startCursor = this.pageInfo.startCursor,
+                endCursor = this.pageInfo.endCursor,
+            ),
+            totalCount = this.totalCount,
+        )
+    }
+
+    private fun ink.radiant.core.domain.model.PostParticipant.toGraphQLUser(): User = toGraphQLUser(
+        id = this.id,
+        username = this.username,
+        name = this.name,
+        avatarUrl = this.avatarUrl,
+        bio = this.bio,
+        location = this.location,
+        websiteUrl = this.websiteUrl,
+        joinedAt = this.joinedAt,
+        postsCount = this.postsCount,
+        viewsCount = this.viewsCount,
+        followersCount = this.followersCount,
+        followingCount = this.followingCount,
+        professionalFields = this.professionalFields,
+    )
+
+    private fun PostAuthor.toGraphQLUser(): User = toGraphQLUser(
+        id = this.id,
+        username = this.username,
+        name = this.name,
+        avatarUrl = this.avatarUrl,
+        bio = this.bio,
+        location = this.location,
+        websiteUrl = this.websiteUrl,
+        joinedAt = this.joinedAt,
+        postsCount = this.postsCount,
+        viewsCount = this.viewsCount,
+        followersCount = this.followersCount,
+        followingCount = this.followingCount,
+        professionalFields = this.professionalFields,
+    )
+
+    private fun toGraphQLUser(
+        id: String,
+        username: String,
+        name: String,
+        avatarUrl: String?,
+        bio: String?,
+        location: String?,
+        websiteUrl: String?,
+        joinedAt: OffsetDateTime,
+        postsCount: Int,
+        viewsCount: Long,
+        followersCount: Int,
+        followingCount: Int,
+        professionalFields: Set<String>,
+    ): User {
+        val graphFields = professionalFields.mapNotNull { field ->
+            runCatching { ProfessionalField.valueOf(field) }.getOrNull()
+        }
+
+        return User(
+            id = id,
+            username = username,
+            name = name,
+            avatarUrl = avatarUrl,
+            bio = bio,
+            location = location,
+            websiteUrl = websiteUrl,
+            joinedAt = joinedAt,
+            postsCount = postsCount,
+            viewsCount = viewsCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+            followersCount = followersCount,
+            followingCount = followingCount,
+            professionalFields = graphFields,
+            followers = emptyUserConnection(),
+            following = emptyUserConnection(),
+            posts = emptyPostConnection(),
+        )
+    }
+
+    private fun emptyUserConnection(): UserConnection = UserConnection(
+        edges = emptyList(),
+        pageInfo = PageInfo(
+            hasNextPage = false,
+            hasPreviousPage = false,
+            startCursor = null,
+            endCursor = null,
+        ),
+        totalCount = 0,
+    )
+
+    private fun emptyPostConnection(): PostConnection = PostConnection(
+        edges = emptyList(),
+        pageInfo = PageInfo(
+            hasNextPage = false,
+            hasPreviousPage = false,
+            startCursor = null,
+            endCursor = null,
+        ),
+        totalCount = 0,
+    )
+
+    private fun storePostsInContext(dfe: DgsDataFetchingEnvironment, posts: List<ink.radiant.core.domain.model.Post>) {
+        if (posts.isEmpty()) {
+            return
+        }
+
+        val context = (dfe.graphQlContext.get(CONTEXT_KEY) as? PostParticipantsContext)
+            ?: PostParticipantsContext().also { dfe.graphQlContext.put(CONTEXT_KEY, it) }
+
+        posts.forEach { post ->
+            context.postsById[post.id.toString()] = post
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_PARTICIPANT_LIMIT = 10
+        private const val CONTEXT_KEY = "radiant-post-context"
+        private const val POST_TYPE = "Post"
+        private const val PARTICIPANTS_FIELD = "participants"
+        private const val AUTHOR_FIELD = "author"
+    }
 }
 
-private fun ink.radiant.core.domain.model.Post.toGraphQLPost(): Post = Post(
-    id = this.id.toString(),
-    title = this.title,
-    body = this.body,
-    translatedTitle = this.translatedTitle,
-    originalSentences = this.originalSentences,
-    translatedSentences = this.translatedSentences,
-    createdAt = this.createdAt,
-    updatedAt = this.updatedAt,
-    likesCount = this.likes,
-    commentsCount = this.commentsCount,
-    thumbnailUrl = this.thumbnailUrl,
-    author = this.authorId?.let { createMockAuthor(it) },
-    participants = UserConnection(
-        edges = emptyList(),
-        pageInfo = PageInfo(
-            hasNextPage = false,
-            hasPreviousPage = false,
-            startCursor = null,
-            endCursor = null,
-        ),
-        totalCount = 0,
-    ),
-)
-
-private fun createMockAuthor(authorId: String): User = User(
-    id = authorId,
-    username = "user_$authorId",
-    name = "Mock User $authorId",
-    avatarUrl = "https://example.com/avatar_$authorId.jpg",
-    bio = "Mock author for post",
-    location = "Seoul, South Korea",
-    websiteUrl = null,
-    joinedAt = OffsetDateTime.now().minusMonths(6),
-    postsCount = 1,
-    viewsCount = 100,
-    followersCount = 10,
-    followingCount = 5,
-    professionalFields = listOf(ProfessionalField.BACKEND),
-    followers = UserConnection(
-        edges = emptyList(),
-        pageInfo = PageInfo(
-            hasNextPage = false,
-            hasPreviousPage = false,
-            startCursor = null,
-            endCursor = null,
-        ),
-        totalCount = 0,
-    ),
-    following = UserConnection(
-        edges = emptyList(),
-        pageInfo = PageInfo(
-            hasNextPage = false,
-            hasPreviousPage = false,
-            startCursor = null,
-            endCursor = null,
-        ),
-        totalCount = 0,
-    ),
-    posts = PostConnection(
-        edges = emptyList(),
-        pageInfo = PageInfo(
-            hasNextPage = false,
-            hasPreviousPage = false,
-            startCursor = null,
-            endCursor = null,
-        ),
-        totalCount = 0,
-    ),
+private class PostParticipantsContext(
+    val postsById: MutableMap<String, ink.radiant.core.domain.model.Post> = mutableMapOf(),
+    val authorsById: MutableMap<String, PostAuthor> = mutableMapOf(),
 )

--- a/radiant-web/src/main/kotlin/ink/radiant/web/datafetcher/PostDataFetcher.kt
+++ b/radiant-web/src/main/kotlin/ink/radiant/web/datafetcher/PostDataFetcher.kt
@@ -138,23 +138,7 @@ class PostDataFetcher(
         )
     }
 
-    private fun ink.radiant.core.domain.model.PostParticipant.toGraphQLUser(): User = toGraphQLUser(
-        id = this.id,
-        username = this.username,
-        name = this.name,
-        avatarUrl = this.avatarUrl,
-        bio = this.bio,
-        location = this.location,
-        websiteUrl = this.websiteUrl,
-        joinedAt = this.joinedAt,
-        postsCount = this.postsCount,
-        viewsCount = this.viewsCount,
-        followersCount = this.followersCount,
-        followingCount = this.followingCount,
-        professionalFields = this.professionalFields,
-    )
-
-    private fun PostAuthor.toGraphQLUser(): User = toGraphQLUser(
+    private fun ink.radiant.core.domain.model.User.toGraphQLUser(): User = toGraphQLUser(
         id = this.id,
         username = this.username,
         name = this.name,

--- a/radiant-web/src/main/kotlin/ink/radiant/web/service/AuthService.kt
+++ b/radiant-web/src/main/kotlin/ink/radiant/web/service/AuthService.kt
@@ -1,7 +1,7 @@
 package ink.radiant.web.service
 
 import ink.radiant.command.service.UserCommandService
-import ink.radiant.core.domain.model.OAuthUser
+import ink.radiant.core.domain.model.OAuthAccount
 import ink.radiant.web.dto.*
 import ink.radiant.web.service.oauth.GitHubOAuthService
 import ink.radiant.web.service.oauth.GoogleOAuthService
@@ -58,7 +58,7 @@ class AuthService(
         }
 
         val user = userCommandService.findOrCreateUser(
-            OAuthUser(
+            OAuthAccount(
                 id = oauthUser.id,
                 username = oauthUser.username,
                 name = oauthUser.name,


### PR DESCRIPTION
## Summary
- Post GraphQL API에 참가자와 작성자 리졸버 추가
- 참가자 커서 기반 페이지네이션 및 도메인 모델/저장소 구현
- 테스트 픽스처 확장과 E2E 검증으로 기능 보강

## Changes
- PostParticipantEntity/Repository를 추가하고 활성 참가자 조회/카운트 쿼리 구현
- PostServiceImpl에 참가자 커넥션/작성자 변환 로직과 커서 헬퍼 추가
- PostQueryService 시그니처 확장 및 PostParticipantConnection 도메인 모델 도입
- PostDataFetcher에서 참가자/작성자 필드 리졸버 구현 및 GraphQL 컨텍스트 캐시 적용
- PostGraphQLTest와 AccountEntityFixture 업데이트로 통합 테스트 시나리오 확장

## Test plan
- [ ] ./gradlew test
- [ ] GraphQL API 수동 확인